### PR TITLE
Fix attribute reader name

### DIFF
--- a/lib/pundit/matchers/utils/all_actions/permitted_actions_error_formatter.rb
+++ b/lib/pundit/matchers/utils/all_actions/permitted_actions_error_formatter.rb
@@ -18,7 +18,7 @@ module Pundit
 
           private
 
-          attr_reader :matcher, :expected_kind, :actual_kind
+          attr_reader :matcher, :expected_kind, :opposite_kind
         end
       end
     end


### PR DESCRIPTION
Hi,

I wasn't able to find references to `actual_kind`. Is it supposed to be `opposite_kind`?