### PR TITLE
Add `*_only_actions` matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ files (by convention, saved in the `spec/policies` directory).
   optional arguments, passed in as parameters, are not permitted by the policy.
 - `forbid_actions(%i[action1 action2])` Tests that an array of actions, passed
   in as a parameter, are not permitted by the policy.
+- `forbid_only_actions(%i[action1 action2])` Tests that an array of actions,
+  passed in as a parameter, are the only actions forbidden by the policy.
 - `forbid_new_and_create_actions` Tests that both the new and create actions
   are not permitted by the policy.
 - `forbid_edit_and_update_actions` Tests that both the edit and update actions

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ files (by convention, saved in the `spec/policies` directory).
   optional arguments, passed in as parameters, are permitted by the policy.
 - `permit_actions(%i[action1 action2])` Tests that an array of actions, passed
   in as a parameter, are permitted by the policy.
+- `permit_only_actions(%i[action1 action2])` Tests that an array of actions,
+  passed in as a parameter, are the only actions permitted by the policy.
 - `permit_new_and_create_actions` Tests that both the new and create actions
   are permitted by the policy.
 - `permit_edit_and_update_actions` Tests that both the edit and update actions

--- a/lib/pundit/matchers.rb
+++ b/lib/pundit/matchers.rb
@@ -8,6 +8,9 @@ module Pundit
     require_relative 'matchers/utils/all_actions/permitted_actions_error_formatter'
     require_relative 'matchers/utils/all_actions/permitted_actions_matcher'
 
+    require_relative 'matchers/utils/only_actions/permitted_actions_error_formatter'
+    require_relative 'matchers/utils/only_actions/permitted_actions_matcher'
+
     class Configuration
       attr_accessor :user_alias
 
@@ -379,6 +382,18 @@ module Pundit
 
     failure_message do
       formatter = Pundit::Matchers::Utils::AllActions::PermittedActionsErrorFormatter.new(@matcher)
+      formatter.message
+    end
+  end
+
+  RSpec::Matchers.define :permit_only_actions do |actions|
+    match do |policy|
+      @matcher = Pundit::Matchers::Utils::OnlyActions::PermittedActionsMatcher.new(policy, actions)
+      @matcher.match?
+    end
+
+    failure_message do
+      formatter = Pundit::Matchers::Utils::OnlyActions::PermittedActionsErrorFormatter.new(@matcher)
       formatter.message
     end
   end

--- a/lib/pundit/matchers.rb
+++ b/lib/pundit/matchers.rb
@@ -8,6 +8,8 @@ module Pundit
     require_relative 'matchers/utils/all_actions/permitted_actions_error_formatter'
     require_relative 'matchers/utils/all_actions/permitted_actions_matcher'
 
+    require_relative 'matchers/utils/only_actions/forbidden_actions_error_formatter'
+    require_relative 'matchers/utils/only_actions/forbidden_actions_matcher'
     require_relative 'matchers/utils/only_actions/permitted_actions_error_formatter'
     require_relative 'matchers/utils/only_actions/permitted_actions_matcher'
 
@@ -406,6 +408,18 @@ module Pundit
 
     failure_message do
       formatter = Pundit::Matchers::Utils::AllActions::ForbiddenActionsErrorFormatter.new(@matcher)
+      formatter.message
+    end
+  end
+
+  RSpec::Matchers.define :forbid_only_actions do |actions|
+    match do |policy|
+      @matcher = Pundit::Matchers::Utils::OnlyActions::ForbiddenActionsMatcher.new(policy, actions)
+      @matcher.match?
+    end
+
+    failure_message do
+      formatter = Pundit::Matchers::Utils::OnlyActions::ForbiddenActionsErrorFormatter.new(@matcher)
       formatter.message
     end
   end

--- a/lib/pundit/matchers/utils/only_actions/actions_matcher.rb
+++ b/lib/pundit/matchers/utils/only_actions/actions_matcher.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Pundit
+  module Matchers
+    module Utils
+      module OnlyActions
+        # Parent class for specific only_action matcher. Should not be used directly.
+        #
+        # Expects methods in child class:
+        # * actual_actions - list of actions which actually matches expected type.
+        class ActionsMatcher
+          attr_reader :policy_info, :expected_actions
+
+          def initialize(policy, expected_actions)
+            @policy_info = PolicyInfo.new(policy)
+            @expected_actions = expected_actions
+          end
+
+          def match?
+            missed_expected_actions.empty? &&
+              actual_actions.sort == expected_actions.sort
+          end
+
+          def unexpected_actions
+            @unexpected_actions ||= actual_actions - expected_actions
+          end
+
+          def missed_expected_actions
+            @missed_expected_actions ||= expected_actions - actual_actions
+          end
+
+          def policy
+            policy_info.policy
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pundit/matchers/utils/only_actions/error_message_formatter.rb
+++ b/lib/pundit/matchers/utils/only_actions/error_message_formatter.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Pundit
+  module Matchers
+    module Utils
+      module OnlyActions
+        # Adds #message method which generates failed assertion message
+        # for *_only_actions matchers.
+        #
+        # Expects methods to be defined:
+        # * matcher - instance which has `OnlyActions::ActionsMatcher` as a parent class
+        # * expected_kind - string with expected actions type (can be "forbidden" or "permitted")
+        # * opposite_kind - string with oposite then expected actions type (can be "permitted" or "forbidden")
+        module ErrorMessageFormatter
+          def message
+            "#{policy_name} expected to have only actions #{matcher.expected_actions} #{expected_kind}, but " \
+            "#{"#{mismatches_are(missed_expected_actions)} #{opposite_kind} and " unless missed_expected_actions.empty?}" \
+            "#{mismatches_are(unexpected_actions)} #{expected_kind} too"
+          end
+
+          private
+
+          attr_reader :matcher, :expected_kind, :opposite_kind
+
+          def policy
+            matcher.policy
+          end
+
+          def unexpected_actions
+            matcher.unexpected_actions
+          end
+
+          def missed_expected_actions
+            matcher.missed_expected_actions
+          end
+
+          def policy_name
+            policy.class.name
+          end
+
+          def mismatches_are(mismatches)
+            if mismatches.count == 1
+              "#{mismatches} is"
+            else
+              "#{mismatches} are"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pundit/matchers/utils/only_actions/forbidden_actions_error_formatter.rb
+++ b/lib/pundit/matchers/utils/only_actions/forbidden_actions_error_formatter.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative 'error_message_formatter'
+
+module Pundit
+  module Matchers
+    module Utils
+      module OnlyActions
+        # Error message formatter for `forbid_only_actions` matcher.
+        class ForbiddenActionsErrorFormatter
+          include OnlyActions::ErrorMessageFormatter
+
+          def initialize(matcher)
+            @expected_kind = 'forbidden'
+            @opposite_kind = 'permitted'
+            @matcher = matcher
+          end
+
+          private
+
+          attr_reader :matcher, :expected_kind, :opposite_kind
+        end
+      end
+    end
+  end
+end

--- a/lib/pundit/matchers/utils/only_actions/forbidden_actions_matcher.rb
+++ b/lib/pundit/matchers/utils/only_actions/forbidden_actions_matcher.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative 'actions_matcher'
+
+module Pundit
+  module Matchers
+    module Utils
+      module OnlyActions
+        # Handles all the checks in `forbid_only_actions` matcher.
+        class ForbiddenActionsMatcher < OnlyActions::ActionsMatcher
+          private
+
+          def actual_actions
+            policy_info.forbidden_actions
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pundit/matchers/utils/only_actions/permitted_actions_error_formatter.rb
+++ b/lib/pundit/matchers/utils/only_actions/permitted_actions_error_formatter.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative 'error_message_formatter'
+
+module Pundit
+  module Matchers
+    module Utils
+      module OnlyActions
+        # Error message formatter for `permit_only_actions` matcher.
+        class PermittedActionsErrorFormatter
+          include OnlyActions::ErrorMessageFormatter
+
+          def initialize(matcher)
+            @expected_kind = 'permitted'
+            @opposite_kind = 'forbidden'
+            @matcher = matcher
+          end
+
+          private
+
+          attr_reader :matcher, :expected_kind, :opposite_kind
+        end
+      end
+    end
+  end
+end

--- a/lib/pundit/matchers/utils/only_actions/permitted_actions_matcher.rb
+++ b/lib/pundit/matchers/utils/only_actions/permitted_actions_matcher.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative 'actions_matcher'
+
+module Pundit
+  module Matchers
+    module Utils
+      module OnlyActions
+        # Handles all the checks in `permit_only_actions` matcher.
+        class PermittedActionsMatcher < OnlyActions::ActionsMatcher
+          private
+
+          def actual_actions
+            policy_info.permitted_actions
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/matchers/forbid_only_actions_spec.rb
+++ b/spec/matchers/forbid_only_actions_spec.rb
@@ -1,0 +1,42 @@
+require 'rspec/core'
+
+describe 'forbid_only_actions matcher' do
+  subject { policy_class.new }
+
+  context 'one action is forbidden' do
+    let(:policy_class) do
+      Class.new do
+        def test?
+          false
+        end
+      end
+    end
+
+    it { is_expected.to forbid_only_actions([:test]) }
+  end
+
+  context 'more than one action is specified' do
+    context 'test1? and test2? are forbidden' do
+      let(:policy_class) do
+        Class.new do
+          def test1?
+            false
+          end
+
+          def test2?
+            false
+          end
+
+          def test3?
+            true
+          end
+        end
+      end
+
+      it { is_expected.to forbid_only_actions([:test1, :test2]) }
+      it { is_expected.to forbid_only_actions([:test2, :test1]) }
+      it { is_expected.not_to forbid_only_actions([:test1]) }
+      it { is_expected.not_to forbid_only_actions([:test3]) }
+    end
+  end
+end

--- a/spec/matchers/permit_only_actions_spec.rb
+++ b/spec/matchers/permit_only_actions_spec.rb
@@ -1,0 +1,42 @@
+require 'rspec/core'
+
+describe 'permit_only_actions matcher' do
+  subject { policy_class.new }
+
+  context 'one action is permitted' do
+    let(:policy_class) do
+      Class.new do
+        def test?
+          true
+        end
+      end
+    end
+
+    it { is_expected.to permit_only_actions([:test]) }
+  end
+
+  context 'more than one action is specified' do
+    context 'test1? and test2? are permitted' do
+      let(:policy_class) do
+        Class.new do
+          def test1?
+            true
+          end
+
+          def test2?
+            true
+          end
+
+          def test3?
+            false
+          end
+        end
+      end
+
+      it { is_expected.to permit_only_actions([:test1, :test2]) }
+      it { is_expected.to permit_only_actions([:test2, :test1]) }
+      it { is_expected.not_to permit_only_actions([:test1]) }
+      it { is_expected.not_to permit_only_actions([:test3]) }
+    end
+  end
+end

--- a/spec/matchers/utils/only_actions/forbidden_actions_error_formatter_spec.rb
+++ b/spec/matchers/utils/only_actions/forbidden_actions_error_formatter_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rspec/core'
+
+RSpec.describe Pundit::Matchers::Utils::OnlyActions::ForbiddenActionsErrorFormatter do
+  subject(:error_message_formatter) do
+    described_class.new(matcher)
+  end
+
+  let(:matcher) do
+    Pundit::Matchers::Utils::OnlyActions::ForbiddenActionsMatcher.new(policy, [:create])
+  end
+
+  let(:policy_class) do
+    Class.new do
+      def self.name
+        'DummyPolicy'
+      end
+
+      def initialize(update, create)
+        @update = update
+        @create = create
+      end
+
+      def update?
+        @update
+      end
+
+      def create?
+        @create
+      end
+    end
+  end
+
+  let(:policy) { policy_class.new(false, false) }
+
+  describe '#message' do
+    subject(:message) { error_message_formatter.message }
+
+    it 'includes unexpected actions in message' do
+      expect(message).to eq('DummyPolicy expected to have only actions [:create] forbidden, but [:update] is forbidden too')
+    end
+  end
+
+  context 'when an expectation is not met' do
+    let(:policy) { policy_class.new(false, true) }
+
+    subject(:message) { error_message_formatter.message }
+
+    it 'includes unexpected actions in message' do
+      expect(message).to eq(
+        'DummyPolicy expected to have only actions [:create] forbidden, ' \
+        'but [:create] is permitted and [:update] is forbidden too'
+      )
+    end
+  end
+end

--- a/spec/matchers/utils/only_actions/forbidden_actions_matcher_spec.rb
+++ b/spec/matchers/utils/only_actions/forbidden_actions_matcher_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rspec/core'
+
+RSpec.describe Pundit::Matchers::Utils::OnlyActions::ForbiddenActionsMatcher do
+  subject(:only_forbidden_actions_matcher) do
+    described_class.new(policy, expected_actions)
+  end
+
+  let(:policy_class) do
+    Class.new do
+      def initialize(update, create)
+        @update = update
+        @create = create
+      end
+
+      def update?
+        @update
+      end
+
+      def create?
+        @create
+      end
+    end
+  end
+
+  let(:policy) { policy_class.new(false, false) }
+  let(:expected_actions) { [:create, :update] }
+
+  describe '#match?' do
+    context 'when policy only forbids expected actions' do
+      it { is_expected.to be_match }
+
+      context 'when expected actions are not ordered' do
+        let(:expected_actions) { [:update, :create] }
+
+        it { is_expected.to be_match }
+      end
+    end
+
+    context 'when policy forbids unexpected actions' do
+      let(:expected_actions) { [:create] }
+
+      it { is_expected.not_to be_match }
+    end
+
+    context 'when policy allows expected actions' do
+      let(:expected_actions) { [:update] }
+
+      it { is_expected.not_to be_match }
+    end
+  end
+
+  describe '#missed_expected_actions' do
+    subject(:missed_expected_actions) { only_forbidden_actions_matcher.missed_expected_actions }
+
+    context 'when policy only forbids expected actions' do
+      it { is_expected.to be_empty }
+    end
+
+    context 'when policy allows expected actions' do
+      let(:policy) { policy_class.new(false, true) }
+
+      it 'returns actions which are forbidden' do
+        expect(missed_expected_actions).to match_array(%i[create])
+      end
+    end
+  end
+
+  describe '#unexpected_actions' do
+    subject(:unexpected_actions) { only_forbidden_actions_matcher.unexpected_actions }
+
+    context 'when policy only forbids expected actions' do
+      it { is_expected.to be_empty }
+    end
+
+    context 'when policy forbids unexpected actions' do
+      let(:expected_actions) { [:create] }
+
+      it 'returns actions which are permitted' do
+        expect(unexpected_actions).to match_array(%i[update])
+      end
+    end
+
+    context 'when policy allows expected actions' do
+      let(:policy) { policy_class.new(false, false) }
+
+      it { is_expected.to be_empty }
+    end
+  end
+end

--- a/spec/matchers/utils/only_actions/permitted_actions_error_formatter_spec.rb
+++ b/spec/matchers/utils/only_actions/permitted_actions_error_formatter_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rspec/core'
+
+RSpec.describe Pundit::Matchers::Utils::OnlyActions::PermittedActionsErrorFormatter do
+  subject(:error_message_formatter) do
+    described_class.new(matcher)
+  end
+
+  let(:matcher) do
+    Pundit::Matchers::Utils::OnlyActions::PermittedActionsMatcher.new(policy, [:create])
+  end
+
+  let(:policy_class) do
+    Class.new do
+      def self.name
+        'DummyPolicy'
+      end
+
+      def initialize(update, create)
+        @update = update
+        @create = create
+      end
+
+      def update?
+        @update
+      end
+
+      def create?
+        @create
+      end
+    end
+  end
+
+  let(:policy) { policy_class.new(true, true) }
+
+  describe '#message' do
+    subject(:message) { error_message_formatter.message }
+
+    it 'includes unexpected actions in message' do
+      expect(message).to eq('DummyPolicy expected to have only actions [:create] permitted, but [:update] is permitted too')
+    end
+  end
+
+  context 'when an expectation is not met' do
+    let(:policy) { policy_class.new(true, false) }
+
+    subject(:message) { error_message_formatter.message }
+
+    it 'includes unexpected actions in message' do
+      expect(message).to eq(
+        'DummyPolicy expected to have only actions [:create] permitted, ' \
+        'but [:create] is forbidden and [:update] is permitted too'
+      )
+    end
+  end
+end

--- a/spec/matchers/utils/only_actions/permitted_actions_matcher_spec.rb
+++ b/spec/matchers/utils/only_actions/permitted_actions_matcher_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rspec/core'
+
+RSpec.describe Pundit::Matchers::Utils::OnlyActions::PermittedActionsMatcher do
+  subject(:only_permitted_actions_matcher) do
+    described_class.new(policy, expected_actions)
+  end
+
+  let(:policy_class) do
+    Class.new do
+      def initialize(update, create)
+        @update = update
+        @create = create
+      end
+
+      def update?
+        @update
+      end
+
+      def create?
+        @create
+      end
+    end
+  end
+
+  let(:policy) { policy_class.new(true, true) }
+  let(:expected_actions) { [:create, :update] }
+
+  describe '#match?' do
+    context 'when policy only allows expected actions' do
+      it { is_expected.to be_match }
+
+      context 'when expected actions are not ordered' do
+        let(:expected_actions) { [:update, :create] }
+
+        it { is_expected.to be_match }
+      end
+    end
+
+    context 'when policy allows unexpected actions' do
+      let(:expected_actions) { [:create] }
+
+      it { is_expected.not_to be_match }
+    end
+
+    context 'when policy forbids expected actions' do
+      let(:expected_actions) { [:update] }
+
+      it { is_expected.not_to be_match }
+    end
+  end
+
+  describe '#missed_expected_actions' do
+    subject(:missed_expected_actions) { only_permitted_actions_matcher.missed_expected_actions }
+
+    context 'when policy only allows expected actions' do
+      it { is_expected.to be_empty }
+    end
+
+    context 'when policy forbids expected actions' do
+      let(:policy) { policy_class.new(true, false) }
+
+      it 'returns actions which are permitted' do
+        expect(missed_expected_actions).to match_array(%i[create])
+      end
+    end
+  end
+
+  describe '#unexpected_actions' do
+    subject(:unexpected_actions) { only_permitted_actions_matcher.unexpected_actions }
+
+    context 'when policy only allows expected actions' do
+      it { is_expected.to be_empty }
+    end
+
+    context 'when policy allows unexpected actions' do
+      let(:expected_actions) { [:create] }
+
+      it 'returns actions which are permitted' do
+        expect(unexpected_actions).to match_array(%i[update])
+      end
+    end
+
+    context 'when policy forbids expected actions' do
+      let(:policy) { policy_class.new(false, false) }
+
+      it { is_expected.to be_empty }
+    end
+  end
+end


### PR DESCRIPTION
Hi, this is a prototype of the feature described in #41

Please let me know what do you think

TODO:
- [x] Readme
- [x] Forbid only
- [ ] Readme section (with explanation of  A01:2021-Broken Access Control)

Close #41