### PR TITLE
Opt-in for MFA requirement

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,13 +13,6 @@ Gemspec/DeprecatedAttributeAssignment:
   Exclude:
     - 'pundit-matchers.gemspec'
 
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: Severity, Include.
-# Include: **/*.gemspec
-Gemspec/RequireMFA:
-  Exclude:
-    - 'pundit-matchers.gemspec'
-
 # Configuration parameters: Severity, Include.
 # Include: **/*.gemspec
 Gemspec/RequiredRubyVersion:

--- a/pundit-matchers.gemspec
+++ b/pundit-matchers.gemspec
@@ -13,4 +13,5 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.add_runtime_dependency 'rspec-rails', '>= 3.0.0'
   s.add_development_dependency 'pundit', '~> 1.1', '>= 1.1.0'
+  s.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
Make the gem more secure by requiring that all privileged operations by any of the owners require OTP.

Ref: https://guides.rubygems.org/mfa-requirement-opt-in/