### PR TITLE
Return policy actions in deterministic order

### DIFF
--- a/lib/pundit/matchers/utils/policy_info.rb
+++ b/lib/pundit/matchers/utils/policy_info.rb
@@ -14,7 +14,7 @@ module Pundit
         def actions
           @actions ||= begin
             policy_methods = @policy.public_methods - Object.instance_methods
-            policy_methods.grep(/\?$/).map { |policy_method| policy_method.to_s.sub(/\?$/, '').to_sym }
+            policy_methods.grep(/\?$/).sort.map { |policy_method| policy_method.to_s.delete_suffix('?').to_sym }
           end
         end
 

--- a/spec/matchers/utils/policy_info_spec.rb
+++ b/spec/matchers/utils/policy_info_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Pundit::Matchers::Utils::PolicyInfo do
     subject(:actions) { policy_info.actions }
 
     it 'returns correct actions' do
-      expect(actions).to match_array(%i[update create new])
+      expect(actions).to eq(%i[create new update])
     end
   end
 
@@ -35,7 +35,7 @@ RSpec.describe Pundit::Matchers::Utils::PolicyInfo do
     subject(:permitted_actions) { policy_info.permitted_actions }
 
     it 'returns actions with "true" result only' do
-      expect(permitted_actions).to match_array(%i[create new])
+      expect(permitted_actions).to eq(%i[create new])
     end
   end
 
@@ -43,7 +43,7 @@ RSpec.describe Pundit::Matchers::Utils::PolicyInfo do
     subject(:forbidden_actions) { policy_info.forbidden_actions }
 
     it 'returns actions with "false" result only' do
-      expect(forbidden_actions).to match_array(%i[update])
+      expect(forbidden_actions).to contain_exactly(:update)
     end
   end
 end


### PR DESCRIPTION
It has been found that the order of public methods is not deterministic
across different Ruby versions.

This change ensures that actions are sorted, so it will be possible
to test failure messages

Also, use `delete_suffix` (introduced in Ruby 2.5) instead of `gsub` for
both clarity and performance

```
Ruby version: 3.2.2
Warming up --------------------------------------
                .sub    33.864k i/100ms
      .delete_suffix    81.945k i/100ms
Calculating -------------------------------------
                .sub    337.215k (± 1.4%) i/s -      1.693M in   5.022133s
      .delete_suffix    821.627k (± 0.8%) i/s -      4.179M in   5.086812s

Comparison:
      .delete_suffix:   821626.8 i/s
                .sub:   337215.0 i/s - 2.44x  (± 0.00) slower

Calculating -------------------------------------
                .sub   816.000  memsize (     0.000  retained)
                        13.000  objects (     0.000  retained)
                         6.000  strings (     0.000  retained)
      .delete_suffix   400.000  memsize (     0.000  retained)
                         9.000  objects (     0.000  retained)
                         6.000  strings (     0.000  retained)

Comparison:
      .delete_suffix:        400 allocated
                .sub:        816 allocated - 2.04x more
```