### PR TITLE
Require RSpec >= 3.12 and drop Pundit < 2.0 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 *.gem
+.byebug_history
 .DS_Store
+.yardoc
 coverage
+doc
 spec/examples.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Pundit Matchers
 
+## 3.0.0 (unreleased)
+
+- Drop RSpec < 3.12 and Pundit < 2 compatibility
+
 ## 2.1.0 (2023-04-28)
 
 - Introduce `permit_only_actions` and `forbid_only_actions` matchers.

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,10 @@
 
 source 'https://rubygems.org'
 
+gemspec
+
 group :development, :test do
   gem 'rake', '~> 13.0'
-  gem 'rspec', '~> 3.12'
   gem 'rubocop', '~> 1.50', require: false
   gem 'rubocop-performance', '~> 1.17', require: false
   gem 'rubocop-rake', '~> 0.6.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+PATH
+  remote: .
+  specs:
+    pundit-matchers (3.0.0)
+      rspec (>= 3.12)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -6,7 +12,7 @@ GEM
     docile (1.4.0)
     json (2.6.3)
     parallel (1.23.0)
-    parser (3.2.2.0)
+    parser (3.2.2.1)
       ast (~> 2.4.1)
     rainbow (3.1.1)
     rake (13.0.6)
@@ -35,18 +41,21 @@ GEM
       rubocop-ast (>= 1.28.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.28.0)
+    rubocop-ast (1.28.1)
       parser (>= 3.2.1.0)
     rubocop-capybara (2.18.0)
       rubocop (~> 1.41)
+    rubocop-factory_bot (2.22.0)
+      rubocop (~> 1.33)
     rubocop-performance (1.17.1)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
-    rubocop-rspec (2.20.0)
+    rubocop-rspec (2.22.0)
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
+      rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
     simplecov (0.22.0)
       docile (~> 1.1)
@@ -60,8 +69,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  pundit-matchers!
   rake (~> 13.0)
-  rspec (~> 3.12)
   rubocop (~> 1.50)
   rubocop-performance (~> 1.17)
   rubocop-rake (~> 0.6.0)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ group:
 
 ```ruby
 group :test do
-  gem 'pundit-matchers', '~> 2.1'
+  gem 'pundit-matchers', '~> 3.0'
 end
 ```
 
@@ -23,10 +23,12 @@ And then execute the following command:
 
 `bundle`
 
-As of Pundit Matchers 2, Ruby 3 is a requirement. Pundit Matchers also requires
-that both the [rspec-rails][rspec-rails-rubygems] (v3.0+) and
-[pundit][pundit-rubygems] (v1.1+) gems are installed. We will drop support for
-older versions of these gems in Pundit Matchers 3.
+Pundit Matchers expects that the application you're testing is using a
+software stack consisting of:
+
+- Ruby 3+
+- Pundit 2+
+- RSpec 3.12+
 
 ## Setup
 
@@ -63,8 +65,6 @@ files (by convention, saved in the `spec/policies` directory).
 - `permit_all_actions` Tests that all actions in the policy are permitted.
 - `permit_action(:action_name)` Tests that an action, passed in as a parameter,
   is permitted by the policy.
-- `permit_action(:action_name, *arguments)` Tests that an action and any
-  optional arguments, passed in as parameters, are permitted by the policy.
 - `permit_actions(%i[action1 action2])` Tests that an array of actions, passed
   in as a parameter, are permitted by the policy.
 - `permit_new_and_create_actions` Tests that both the new and create actions
@@ -83,8 +83,6 @@ files (by convention, saved in the `spec/policies` directory).
 - `forbid_all_actions` Tests that all actions in the policy are forbidden.
 - `forbid_action(:action_name)` Tests that an action, passed in as a parameter,
   is not permitted by the policy.
-- `forbid_action(:action_name, *arguments)` Tests that an action and any
-  optional arguments, passed in as parameters, are not permitted by the policy.
 - `forbid_actions(%i[action1 action2])` Tests that an array of actions, passed
   in as a parameter, are not permitted by the policy.
 - `forbid_new_and_create_actions` Tests that both the new and create actions
@@ -389,54 +387,6 @@ RSpec.describe ArticlePolicy do
     let(:user) { User.new(administrator: true) }
 
     it { is_expected.to permit_new_and_create_actions }
-  end
-end
-```
-
-## Testing Actions With Arguments
-
-Warning: this feature is deprecated and will be removed in Pundit Matchers 3.
-Pundit does not support passing additional arguments to policies in Pundit 2. To
-pass extra information besides the user and record to a policy action, you
-should set up a [user context][pundit-github-additional-context] in the
-controller.
-
-Sometimes you may have a custom policy action which accepts one or more
-arguments. Pundit Matchers allows you to specify a number of optional arguments
-to the `permit_action` and `forbid_action` matchers so that actions with
-arguments can be tested. For example, you might have a policy with a
-`create_comment?` method that takes the comment as an argument, like this:
-
-```ruby
-class ArticlePolicy < ApplicationPolicy
-  def create_comment?(comment)
-    true unless comment.spam
-  end
-end
-```
-
-To test this, we can simply pass the comment to the permit or forbid action
-matcher.
-
-```ruby
-require 'rails_helper'
-
-RSpec.describe ArticlePolicy do
-  subject { described_class.new(user, article) }
-
-  let(:user) { nil }
-  let(:article) { Article.new }
-
-  context 'when comment is spam' do
-    let(:comment) { Comment.new(spam: true) }
-
-    it { is_expected.to forbid_action(:create_comment, comment) }
-  end
-
-  context 'when comment is not spam' do
-    let(:comment) { Comment.new(spam: false) }
-
-    it { is_expected.to permit_action(:create_comment, comment) }
   end
 end
 ```
@@ -749,9 +699,6 @@ Run Rubocop: `docker build . && docker-compose run lib bin/rubocop`
 [github-actions-rubocop-badge]: https://github.com/punditcommunity/pundit-matchers/actions/workflows/rubocop.yml/badge.svg
 [pundit-github]: https://github.com/varvet/pundit
 [thunderbolt-labs]: https://www.thunderboltlabs.com/blog/2013/03/27/testing-pundit-policies-with-rspec/
-[rspec-rails-rubygems]: https://rubygems.org/gems/rspec-rails
-[pundit-rubygems]: https://rubygems.org/gems/pundit
 [owasp-top-10]: https://owasp.org/Top10/
 [broken-access-control]: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
-[pundit-github-additional-context]: https://github.com/varvet/pundit#additional-context
 [ruby-style-guide]: https://github.com/bbatsov/ruby-style-guide

--- a/lib/pundit/matchers.rb
+++ b/lib/pundit/matchers.rb
@@ -34,13 +34,9 @@ module Pundit
     end
   end
 
-  RSpec::Matchers.define :forbid_action do |action, *args, **kwargs|
+  RSpec::Matchers.define :forbid_action do |action|
     match do |policy|
-      if args.any?
-        !policy.public_send("#{action}?", *args, **kwargs)
-      else
-        !policy.public_send("#{action}?", **kwargs)
-      end
+      !policy.public_send(:"#{action}?")
     end
 
     failure_message do |policy|
@@ -185,13 +181,9 @@ module Pundit
     end
   end
 
-  RSpec::Matchers.define :permit_action do |action, *args, **kwargs|
+  RSpec::Matchers.define :permit_action do |action|
     match do |policy|
-      if args.any?
-        policy.public_send("#{action}?", *args, **kwargs)
-      else
-        policy.public_send("#{action}?", **kwargs)
-      end
+      policy.public_send(:"#{action}?")
     end
 
     failure_message do |policy|

--- a/pundit-matchers.gemspec
+++ b/pundit-matchers.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'pundit-matchers'
-  s.version     = '2.1.0'
+  s.version     = '3.0.0'
   s.summary     = 'RSpec matchers for Pundit policies'
   s.description = 'A set of RSpec matchers for testing Pundit authorisation ' \
                   'policies'
@@ -12,8 +12,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.homepage    = 'https://github.com/punditcommunity/pundit-matchers'
   s.license     = 'MIT'
-  s.add_runtime_dependency 'rspec-rails', '>= 3.0.0'
-  s.add_development_dependency 'pundit', '~> 1.1', '>= 1.1.0'
+  s.add_runtime_dependency 'rspec', '>= 3.12'
   s.metadata['rubygems_mfa_required'] = 'true'
   s.required_ruby_version = '>= 3.0'
 end

--- a/spec/matchers/forbid_action_spec.rb
+++ b/spec/matchers/forbid_action_spec.rb
@@ -5,103 +5,41 @@ require 'rspec/core'
 RSpec.describe 'forbid_action matcher' do
   subject(:policy) { policy_class.new }
 
-  context 'when no optional arguments are specified' do
-    context 'when test? is permitted' do
-      let(:policy_class) do
-        Class.new(TestPolicy) do
-          def test?
-            true
-          end
+  context 'when test? is permitted' do
+    let(:policy_class) do
+      Class.new(TestPolicy) do
+        def test?
+          true
         end
-      end
-
-      it { is_expected.not_to forbid_action(:test) }
-
-      it 'provides a user friendly failure message' do
-        expect do
-          expect(policy).to forbid_action(:test)
-        end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                           'TestPolicy does not forbid test for "user".')
       end
     end
 
-    context 'when test? is forbidden' do
-      let(:policy_class) do
-        Class.new(TestPolicy) do
-          def test?
-            false
-          end
-        end
-      end
+    it { is_expected.not_to forbid_action(:test) }
 
-      it { is_expected.to forbid_action(:test) }
-
-      it 'provides a user friendly negated failure message' do
-        expect do
-          expect(policy).not_to forbid_action(:test)
-        end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                           'TestPolicy does not permit test for "user".')
-      end
+    it 'provides a user friendly failure message' do
+      expect do
+        expect(policy).to forbid_action(:test)
+      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
+                         'TestPolicy does not forbid test for "user".')
     end
   end
 
-  context 'when one optional argument is specified' do
-    context 'when test? with optional argument is permitted' do
-      let(:policy_class) do
-        Class.new(TestPolicy) do
-          def test?(argument)
-            raise unless argument == 'argument'
-
-            true
-          end
+  context 'when test? is forbidden' do
+    let(:policy_class) do
+      Class.new(TestPolicy) do
+        def test?
+          false
         end
       end
-
-      it { is_expected.not_to forbid_action(:test, 'argument') }
     end
 
-    context 'when test? with optional argument is forbidden' do
-      let(:policy_class) do
-        Class.new(TestPolicy) do
-          def test?(argument)
-            raise unless argument == 'argument'
+    it { is_expected.to forbid_action(:test) }
 
-            false
-          end
-        end
-      end
-
-      it { is_expected.to forbid_action(:test, 'argument') }
-    end
-  end
-
-  context 'when more than one argument is specified' do
-    context 'when test? with optional arguments is permitted' do
-      let(:policy_class) do
-        Class.new(TestPolicy) do
-          def test?(one, two, three)
-            raise unless one == 'one' && two == 'two' && three == 'three'
-
-            true
-          end
-        end
-      end
-
-      it { is_expected.not_to forbid_action(:test, 'one', 'two', 'three') }
-    end
-
-    context 'when test? with optional arguments is forbidden' do
-      let(:policy_class) do
-        Class.new(TestPolicy) do
-          def test?(one, two, three)
-            raise unless one == 'one' && two == 'two' && three == 'three'
-
-            false
-          end
-        end
-      end
-
-      it { is_expected.to forbid_action(:test, 'one', 'two', 'three') }
+    it 'provides a user friendly negated failure message' do
+      expect do
+        expect(policy).not_to forbid_action(:test)
+      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
+                         'TestPolicy does not permit test for "user".')
     end
   end
 end

--- a/spec/matchers/permit_action_spec.rb
+++ b/spec/matchers/permit_action_spec.rb
@@ -5,103 +5,41 @@ require 'rspec/core'
 RSpec.describe 'permit_action matcher' do
   subject(:policy) { policy_class.new }
 
-  context 'when no arguments are specified' do
-    context 'when test? is permitted' do
-      let(:policy_class) do
-        Class.new(TestPolicy) do
-          def test?
-            true
-          end
+  context 'when test? is permitted' do
+    let(:policy_class) do
+      Class.new(TestPolicy) do
+        def test?
+          true
         end
-      end
-
-      it { is_expected.to permit_action(:test) }
-
-      it 'provides a user friendly negated failure message' do
-        expect do
-          expect(policy).not_to permit_action(:test)
-        end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                           'TestPolicy does not forbid test for "user".')
       end
     end
 
-    context 'when test? is forbidden' do
-      let(:policy_class) do
-        Class.new(TestPolicy) do
-          def test?
-            false
-          end
-        end
-      end
+    it { is_expected.to permit_action(:test) }
 
-      it { is_expected.not_to permit_action(:test) }
-
-      it 'provides a user friendly failure message' do
-        expect do
-          expect(policy).to permit_action(:test)
-        end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                           'TestPolicy does not permit test for "user".')
-      end
+    it 'provides a user friendly negated failure message' do
+      expect do
+        expect(policy).not_to permit_action(:test)
+      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
+                         'TestPolicy does not forbid test for "user".')
     end
   end
 
-  context 'when one argument is specified' do
-    context 'when test? with optional argument is permitted' do
-      let(:policy_class) do
-        Class.new(TestPolicy) do
-          def test?(argument)
-            raise unless argument == 'argument'
-
-            true
-          end
+  context 'when test? is forbidden' do
+    let(:policy_class) do
+      Class.new(TestPolicy) do
+        def test?
+          false
         end
       end
-
-      it { is_expected.to permit_action(:test, 'argument') }
     end
 
-    context 'when test? with optional argument is forbidden' do
-      let(:policy_class) do
-        Class.new(TestPolicy) do
-          def test?(argument)
-            raise unless argument == 'argument'
+    it { is_expected.not_to permit_action(:test) }
 
-            false
-          end
-        end
-      end
-
-      it { is_expected.not_to permit_action(:test, 'argument') }
-    end
-  end
-
-  context 'when more than one argument is specified' do
-    context 'when test? with optional arguments is permitted' do
-      let(:policy_class) do
-        Class.new(TestPolicy) do
-          def test?(one, two, three)
-            raise unless one == 'one' && two == 'two' && three == 'three'
-
-            true
-          end
-        end
-      end
-
-      it { is_expected.to permit_action(:test, 'one', 'two', 'three') }
-    end
-
-    context 'when test? with optional arguments is forbidden' do
-      let(:policy_class) do
-        Class.new(TestPolicy) do
-          def test?(one, two, three)
-            raise unless one == 'one' && two == 'two' && three == 'three'
-
-            false
-          end
-        end
-      end
-
-      it { is_expected.not_to permit_action(:test, 'one', 'two', 'three') }
+    it 'provides a user friendly failure message' do
+      expect do
+        expect(policy).to permit_action(:test)
+      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
+                         'TestPolicy does not permit test for "user".')
     end
   end
 end


### PR DESCRIPTION
Also:
- Bump major version
- Replace RSpec-rails with RSpec
- Do not require pundit (it was not used)
- Add debug and documentation files to gitignore
- Update Gemfile.lock

Close #67
