### PR TITLE
Use `fail_with` helper (no changes to production code)

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -9,11 +9,11 @@
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns, inherit_mode.
 # AllowedMethods: refine
 Metrics/BlockLength:
-  Max: 54
+  Max: 50
 
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
-  Max: 314
+  Max: 301
 
 RSpec/MultipleExpectations:
   Max: 2

--- a/spec/matchers/forbid_action_spec.rb
+++ b/spec/matchers/forbid_action_spec.rb
@@ -19,8 +19,7 @@ RSpec.describe 'forbid_action matcher' do
     it 'provides a user friendly failure message' do
       expect do
         expect(policy).to forbid_action(:test)
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                         'TestPolicy does not forbid test for "user".')
+      end.to fail_with('TestPolicy does not forbid test for "user".')
     end
   end
 
@@ -38,8 +37,7 @@ RSpec.describe 'forbid_action matcher' do
     it 'provides a user friendly negated failure message' do
       expect do
         expect(policy).not_to forbid_action(:test)
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                         'TestPolicy does not permit test for "user".')
+      end.to fail_with('TestPolicy does not permit test for "user".')
     end
   end
 end

--- a/spec/matchers/forbid_actions_spec.rb
+++ b/spec/matchers/forbid_actions_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe 'forbid_actions matcher' do
     it 'provides a user friendly failure message' do
       expect do
         expect(policy).to forbid_actions([])
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                         'At least one action must be specified when using the forbid_actions matcher.')
+      end.to fail_with('At least one action must be specified when using the forbid_actions matcher.')
     end
   end
 
@@ -34,9 +33,8 @@ RSpec.describe 'forbid_actions matcher' do
     it 'provides a user friendly failure message' do
       expect do
         expect(policy).to forbid_actions([:test])
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                         'TestPolicy expected to forbid [:test], ' \
-                         'but permitted [:test] for "user".')
+      end.to fail_with('TestPolicy expected to forbid [:test], ' \
+                       'but permitted [:test] for "user".')
     end
   end
 
@@ -107,9 +105,8 @@ RSpec.describe 'forbid_actions matcher' do
       it 'provides a user friendly negated failure message' do
         expect do
           expect(policy).not_to forbid_actions(%i[test1 test2])
-        end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                           'TestPolicy expected to permit [:test1, :test2], ' \
-                           'but forbade [] for "user".')
+        end.to fail_with('TestPolicy expected to permit [:test1, :test2], ' \
+                         'but forbade [] for "user".')
       end
     end
   end

--- a/spec/matchers/forbid_all_actions_spec.rb
+++ b/spec/matchers/forbid_all_actions_spec.rb
@@ -25,9 +25,8 @@ RSpec.describe 'forbid_all_actions matcher' do
     it 'provides a user friendly failure message' do
       expect do
         expect(policy).to forbid_all_actions
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                         'TestPolicy expected to have all actions forbidden, ' \
-                         'but [:test] is permitted')
+      end.to fail_with('TestPolicy expected to have all actions forbidden, ' \
+                       'but [:test] is permitted')
     end
   end
 

--- a/spec/matchers/forbid_edit_and_update_actions_spec.rb
+++ b/spec/matchers/forbid_edit_and_update_actions_spec.rb
@@ -23,8 +23,7 @@ RSpec.describe 'forbid_edit_and_update_actions matcher' do
     it 'provides a user friendly failure message' do
       expect do
         expect(policy).to forbid_edit_and_update_actions
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                         'TestPolicy does not forbid the edit or update action for "user".')
+      end.to fail_with('TestPolicy does not forbid the edit or update action for "user".')
     end
   end
 
@@ -78,8 +77,7 @@ RSpec.describe 'forbid_edit_and_update_actions matcher' do
     it 'provides a user friendly negated failure message' do
       expect do
         expect(policy).not_to forbid_edit_and_update_actions
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                         'TestPolicy does not permit the edit or update action for "user".')
+      end.to fail_with('TestPolicy does not permit the edit or update action for "user".')
     end
   end
 end

--- a/spec/matchers/forbid_mass_assignment_of_spec.rb
+++ b/spec/matchers/forbid_mass_assignment_of_spec.rb
@@ -24,25 +24,22 @@ RSpec.describe 'forbid_mass_assignment_of matcher' do
       it 'provides a user friendly failure message' do
         expect do
           expect(policy).to forbid_mass_assignment_of([])
-        end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                           'At least one attribute must be specified when using the forbid_mass_assignment_of matcher.')
+        end.to fail_with('At least one attribute must be specified when using the forbid_mass_assignment_of matcher.')
       end
     end
 
     it 'provides a user friendly failure message' do
       expect do
         expect(policy).to forbid_mass_assignment_of(:bar)
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                         'TestPolicy expected to forbid the mass assignment of the attributes [:bar], ' \
-                         'but permitted the mass assignment of the attributes [:bar] for "user".')
+      end.to fail_with('TestPolicy expected to forbid the mass assignment of the attributes [:bar], ' \
+                       'but permitted the mass assignment of the attributes [:bar] for "user".')
     end
 
     it 'provides a user friendly negated failure message' do
       expect do
         expect(policy).not_to forbid_mass_assignment_of(:baz)
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                         'TestPolicy expected to permit the mass assignment of the attributes [:baz], ' \
-                         'but permitted the mass assignment of the attributes [] for "user".')
+      end.to fail_with('TestPolicy expected to permit the mass assignment of the attributes [:baz], ' \
+                       'but permitted the mass assignment of the attributes [] for "user".')
     end
   end
 
@@ -102,19 +99,17 @@ RSpec.describe 'forbid_mass_assignment_of matcher' do
     it 'provides a user friendly failure message' do
       expect do
         expect(policy).to forbid_mass_assignment_of(:bar).for_action(:test)
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                         'TestPolicy expected to forbid the mass assignment of the attributes [:bar] ' \
-                         'when authorising the test action, ' \
-                         'but permitted the mass assignment of the attributes [:bar] for "user".')
+      end.to fail_with('TestPolicy expected to forbid the mass assignment of the attributes [:bar] ' \
+                       'when authorising the test action, ' \
+                       'but permitted the mass assignment of the attributes [:bar] for "user".')
     end
 
     it 'provides a user friendly negated failure message' do
       expect do
         expect(policy).not_to forbid_mass_assignment_of(:baz).for_action(:test)
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                         'TestPolicy expected to permit the mass assignment of the attributes [:baz] ' \
-                         'when authorising the test action, ' \
-                         'but permitted the mass assignment of the attributes [] for "user".')
+      end.to fail_with('TestPolicy expected to permit the mass assignment of the attributes [:baz] ' \
+                       'when authorising the test action, ' \
+                       'but permitted the mass assignment of the attributes [] for "user".')
     end
   end
 

--- a/spec/matchers/forbid_new_and_create_actions_spec.rb
+++ b/spec/matchers/forbid_new_and_create_actions_spec.rb
@@ -23,8 +23,7 @@ RSpec.describe 'forbid_new_and_create_actions matcher' do
     it 'provides a user friendly failure message' do
       expect do
         expect(policy).to forbid_new_and_create_actions
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                         'TestPolicy does not forbid the new or create action for "user".')
+      end.to fail_with('TestPolicy does not forbid the new or create action for "user".')
     end
   end
 
@@ -78,8 +77,7 @@ RSpec.describe 'forbid_new_and_create_actions matcher' do
     it 'provides a user friendly negated failure message' do
       expect do
         expect(policy).not_to forbid_new_and_create_actions
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                         'TestPolicy does not permit the new or create action for "user".')
+      end.to fail_with('TestPolicy does not permit the new or create action for "user".')
     end
   end
 end

--- a/spec/matchers/forbid_only_actions_spec.rb
+++ b/spec/matchers/forbid_only_actions_spec.rb
@@ -43,9 +43,8 @@ RSpec.describe 'forbid_only_actions matcher' do
       it 'provides a user friendly failure message' do
         expect do
           expect(policy).to forbid_only_actions([:test1])
-        end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                           'TestPolicy expected to have only actions [:test1] forbidden, ' \
-                           'but [:test2] is forbidden too')
+        end.to fail_with('TestPolicy expected to have only actions [:test1] forbidden, ' \
+                         'but [:test2] is forbidden too')
       end
     end
   end

--- a/spec/matchers/permit_action_spec.rb
+++ b/spec/matchers/permit_action_spec.rb
@@ -19,8 +19,7 @@ RSpec.describe 'permit_action matcher' do
     it 'provides a user friendly negated failure message' do
       expect do
         expect(policy).not_to permit_action(:test)
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                         'TestPolicy does not forbid test for "user".')
+      end.to fail_with('TestPolicy does not forbid test for "user".')
     end
   end
 
@@ -38,8 +37,7 @@ RSpec.describe 'permit_action matcher' do
     it 'provides a user friendly failure message' do
       expect do
         expect(policy).to permit_action(:test)
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                         'TestPolicy does not permit test for "user".')
+      end.to fail_with('TestPolicy does not permit test for "user".')
     end
   end
 end

--- a/spec/matchers/permit_actions_spec.rb
+++ b/spec/matchers/permit_actions_spec.rb
@@ -30,8 +30,7 @@ RSpec.describe 'permit_actions matcher' do
     it 'provides a user friendly failure message' do
       expect do
         expect(policy).to permit_actions([])
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                         'At least one action must be specified when using the permit_actions matcher.')
+      end.to fail_with('At least one action must be specified when using the permit_actions matcher.')
     end
   end
 
@@ -82,17 +81,15 @@ RSpec.describe 'permit_actions matcher' do
       it 'provides a user friendly failure message' do
         expect do
           expect(policy).to permit_actions(%i[test2])
-        end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                           'TestPolicy expected to permit [:test2], ' \
-                           'but forbade [:test2] for "user".')
+        end.to fail_with('TestPolicy expected to permit [:test2], ' \
+                         'but forbade [:test2] for "user".')
       end
 
       it 'provides a user friendly negated failure message' do
         expect do
           expect(policy).not_to permit_actions(%i[test1])
-        end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                           'TestPolicy expected to forbid [:test1], ' \
-                           'but permitted [] for "user".')
+        end.to fail_with('TestPolicy expected to forbid [:test1], ' \
+                         'but permitted [] for "user".')
       end
     end
 

--- a/spec/matchers/permit_all_actions_spec.rb
+++ b/spec/matchers/permit_all_actions_spec.rb
@@ -58,9 +58,8 @@ RSpec.describe 'permit_all_actions matcher' do
       it 'provides a user friendly failure message' do
         expect do
           expect(policy).to permit_all_actions
-        end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                           'TestPolicy expected to have all actions permitted, ' \
-                           'but [:test2] is forbidden')
+        end.to fail_with('TestPolicy expected to have all actions permitted, ' \
+                         'but [:test2] is forbidden')
       end
     end
 

--- a/spec/matchers/permit_edit_and_update_actions_spec.rb
+++ b/spec/matchers/permit_edit_and_update_actions_spec.rb
@@ -23,8 +23,7 @@ RSpec.describe 'permit_edit_and_update_actions matcher' do
     it 'provides a user friendly failure message' do
       expect do
         expect(policy).not_to permit_edit_and_update_actions
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                         'TestPolicy does not forbid the edit or update action for "user".')
+      end.to fail_with('TestPolicy does not forbid the edit or update action for "user".')
     end
   end
 
@@ -78,8 +77,7 @@ RSpec.describe 'permit_edit_and_update_actions matcher' do
     it 'provides a user friendly failure message' do
       expect do
         expect(policy).to permit_edit_and_update_actions
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                         'TestPolicy does not permit the edit or update action for "user".')
+      end.to fail_with('TestPolicy does not permit the edit or update action for "user".')
     end
   end
 end

--- a/spec/matchers/permit_mass_assignment_of_spec.rb
+++ b/spec/matchers/permit_mass_assignment_of_spec.rb
@@ -24,25 +24,22 @@ RSpec.describe 'permit_mass_assignment_of matcher' do
       it 'provides a user friendly failure message' do
         expect do
           expect(policy).to permit_mass_assignment_of([])
-        end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                           'At least one attribute must be specified when using the permit_mass_assignment_of matcher.')
+        end.to fail_with('At least one attribute must be specified when using the permit_mass_assignment_of matcher.')
       end
     end
 
     it 'provides a user friendly failure message' do
       expect do
         expect(policy).to permit_mass_assignment_of(:baz)
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                         'TestPolicy expected to permit the mass assignment of the attributes [:baz], ' \
-                         'but forbade the mass assignment of the attributes [:baz] for "user".')
+      end.to fail_with('TestPolicy expected to permit the mass assignment of the attributes [:baz], ' \
+                       'but forbade the mass assignment of the attributes [:baz] for "user".')
     end
 
     it 'provides a user friendly negated failure message' do
       expect do
         expect(policy).not_to permit_mass_assignment_of(:bar)
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                         'TestPolicy expected to forbid the mass assignment of the attributes [:bar], ' \
-                         'but forbade the mass assignment of the attributes [] for "user".')
+      end.to fail_with('TestPolicy expected to forbid the mass assignment of the attributes [:bar], ' \
+                       'but forbade the mass assignment of the attributes [] for "user".')
     end
   end
 
@@ -102,19 +99,17 @@ RSpec.describe 'permit_mass_assignment_of matcher' do
     it 'provides a user friendly failure message' do
       expect do
         expect(policy).to permit_mass_assignment_of(:baz).for_action(:test)
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                         'TestPolicy expected to permit the mass assignment of the attributes [:baz] ' \
-                         'when authorising the test action, ' \
-                         'but forbade the mass assignment of the attributes [:baz] for "user".')
+      end.to fail_with('TestPolicy expected to permit the mass assignment of the attributes [:baz] ' \
+                       'when authorising the test action, ' \
+                       'but forbade the mass assignment of the attributes [:baz] for "user".')
     end
 
     it 'provides a user friendly negated failure message' do
       expect do
         expect(policy).not_to permit_mass_assignment_of(:bar).for_action(:test)
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                         'TestPolicy expected to forbid the mass assignment of the attributes [:bar] ' \
-                         'when authorising the test action, ' \
-                         'but forbade the mass assignment of the attributes [] for "user".')
+      end.to fail_with('TestPolicy expected to forbid the mass assignment of the attributes [:bar] ' \
+                       'when authorising the test action, ' \
+                       'but forbade the mass assignment of the attributes [] for "user".')
     end
   end
 

--- a/spec/matchers/permit_new_and_create_actions_spec.rb
+++ b/spec/matchers/permit_new_and_create_actions_spec.rb
@@ -23,8 +23,7 @@ RSpec.describe 'permit_new_and_create_actions matcher' do
     it 'provides a user friendly negated failure message' do
       expect do
         expect(policy).not_to permit_new_and_create_actions
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                         'TestPolicy does not forbid the new or create action for "user".')
+      end.to fail_with('TestPolicy does not forbid the new or create action for "user".')
     end
   end
 
@@ -46,8 +45,7 @@ RSpec.describe 'permit_new_and_create_actions matcher' do
     it 'provides a user friendly failure message' do
       expect do
         expect(policy).to permit_new_and_create_actions
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                         'TestPolicy does not permit the new or create action for "user".')
+      end.to fail_with('TestPolicy does not permit the new or create action for "user".')
     end
   end
 

--- a/spec/matchers/permit_only_actions_spec.rb
+++ b/spec/matchers/permit_only_actions_spec.rb
@@ -43,9 +43,8 @@ RSpec.describe 'permit_only_actions matcher' do
       it 'provides a user friendly failure message' do
         expect do
           expect(policy).to permit_only_actions([:test1])
-        end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                           'TestPolicy expected to have only actions [:test1] permitted, ' \
-                           'but [:test2] is permitted too')
+        end.to fail_with('TestPolicy expected to have only actions [:test1] permitted, ' \
+                         'but [:test2] is permitted too')
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,8 @@ if ENV['COVERAGE']
   end
 end
 
+require 'rspec/matchers/fail_matchers'
+
 require 'pundit/matchers'
 require_relative 'test_policies'
 
@@ -26,6 +28,8 @@ require_relative 'test_policies'
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  config.include RSpec::Matchers::FailMatchers
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
They are available in the public API of rspec-expectations

Ref: https://rubydoc.info/gems/rspec-expectations/RSpec/Matchers/FailMatchers