### PR TITLE
Remove conditional check of Pundit definition

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -9,11 +9,11 @@
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns, inherit_mode.
 # AllowedMethods: refine
 Metrics/BlockLength:
-  Max: 54
+  Max: 50
 
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
-  Max: 314
+  Max: 301
 
 RSpec/MultipleExpectations:
   Max: 2

--- a/lib/pundit/matchers.rb
+++ b/lib/pundit/matchers.rb
@@ -398,8 +398,6 @@ module Pundit
   end
 end
 
-if defined?(Pundit)
-  RSpec.configure do |config|
-    config.include Pundit::Matchers
-  end
+RSpec.configure do |config|
+  config.include Pundit::Matchers
 end


### PR DESCRIPTION
Pundit module is declared in the same file, so this check is redundant

Close #74

---

I've tried this locally (`gem 'pundit-matchers', path: '~/path/to/pundit-matchers'`), but not as a gem. However, at the moment I cannot see how Pundit is not defined in that file at the moment of the check