### PR TITLE
Minor improvements to Policy Info

### DIFF
--- a/lib/pundit/matchers/utils/policy_info.rb
+++ b/lib/pundit/matchers/utils/policy_info.rb
@@ -3,27 +3,48 @@
 module Pundit
   module Matchers
     module Utils
-      # Collects all details about given policy class.
+      # This class provides methods to retrieve information about a policy class,
+      # such as the actions it defines and which of those actions are permitted
+      # or forbidden.
       class PolicyInfo
         attr_reader :policy
 
+        # Initializes a new instance of PolicyInfo.
+        #
+        # @param policy [Class] The policy class to collect details about.
         def initialize(policy)
           @policy = policy
         end
 
+        # Returns an array of all actions defined in the policy class.
+        #
+        # It assumes that actions are defined as public instance methods that end with a question mark.
+        #
+        # @return [Array<Symbol>] An array of all actions defined in the policy class.
         def actions
-          @actions ||= begin
-            policy_methods = @policy.public_methods - Object.instance_methods
-            policy_methods.grep(/\?$/).sort.map { |policy_method| policy_method.to_s.delete_suffix('?').to_sym }
+          @actions ||= policy_public_methods.grep(/\?$/).sort.map do |policy_method|
+            policy_method.to_s.delete_suffix('?').to_sym
           end
         end
 
+        # Returns an array of all permitted actions defined in the policy class.
+        #
+        # @return [Array<Symbol>] An array of all permitted actions defined in the policy class.
         def permitted_actions
-          @permitted_actions ||= actions.select { |action| policy.public_send("#{action}?") }
+          @permitted_actions ||= actions.select { |action| policy.public_send(:"#{action}?") }
         end
 
+        # Returns an array of all forbidden actions defined in the policy class.
+        #
+        # @return [Array<Symbol>] An array of all forbidden actions defined in the policy class.
         def forbidden_actions
-          actions - permitted_actions
+          @forbidden_actions ||= actions - permitted_actions
+        end
+
+        private
+
+        def policy_public_methods
+          @policy_public_methods ||= policy.public_methods - Object.instance_methods
         end
       end
     end


### PR DESCRIPTION
- Add YARD documentation
- Memoize forbidden actions for parity with permitted actions
- Use attribute accessor to access `policy`
- Move public policy methods to a memoized private method

---

May not look immediate why, but this is going to help in implementing #24 (and improve the attribute matcher class)

We can have something like

```rb
def permitted_attributes_actions
  @permitted_attributes_actions ||= public_policy_methods.grep(/\Apermitted_attributes(_for_.+)?\z/).sort
end
```