### PR TITLE
Improve development dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,14 +4,10 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :development, :test do
-  gem 'rake', '~> 13.0'
-  gem 'rubocop', '~> 1.51', require: false
-  gem 'rubocop-performance', '~> 1.18', require: false
-  gem 'rubocop-rake', '~> 0.6.0', require: false
-  gem 'rubocop-rspec', '~> 2.19', require: false
-end
-
-group :test do
-  gem 'simplecov', '~> 0.22.0', require: false
-end
+gem 'bundler', '~> 2.4'
+gem 'rake', '~> 13.0'
+gem 'rubocop', '~> 1.51', require: false
+gem 'rubocop-performance', '~> 1.18', require: false
+gem 'rubocop-rake', '~> 0.6.0', require: false
+gem 'rubocop-rspec', '~> 2.19', require: false
+gem 'simplecov', '~> 0.22.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bundler (~> 2.4)
   pundit-matchers!
   rake (~> 13.0)
   rubocop (~> 1.51)

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)


### PR DESCRIPTION
- Add `bundler` to development dependencies
- Add `bundler/gem_tasks` to Rakefile to simplify release process
- Remove groups from `Gemfile`, they are redundant for gem development

Ref: #91