### PR TITLE
Introduce permit/forbid attributes matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Pundit Matchers
 
+## 3.1.0 (unreleased)
+
+- Add `*_attribute(s)` matchers for uniformity with `*_action(s)`
+
 ## 3.0.1 (2023-06-17)
 
 - Allow to match dynamically defined actions

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pundit-matchers (3.0.1)
+    pundit-matchers (3.1.0)
       rspec-core (~> 3.12)
       rspec-expectations (~> 3.12)
       rspec-mocks (~> 3.12)

--- a/lib/pundit/matchers.rb
+++ b/lib/pundit/matchers.rb
@@ -152,15 +152,32 @@ module Pundit
       ForbidOnlyActionsMatcher.new(*actions)
     end
 
+    # Creates a matcher that tests if the policy permits mass assignment of an attribute.
+    #
+    # @param [String, Symbol, Hash] attribute the attribute to be tested.
+    # @return [PermitAttributesMatcher] the matcher object.
+    def permit_attribute(attribute)
+      PermitAttributesMatcher.new(attribute).ensure_single_attribute!
+    end
+
+    RSpec::Matchers.define_negated_matcher :forbid_attribute, :permit_attribute, &NEGATED_DESCRIPTION
+
     # Creates a matcher that tests if the policy permits mass assignment of a set of attributes.
     #
     # @param [Array<String, Symbol, Hash>] attributes the attributes to be tested.
     # @return [PermitAttributesMatcher] the matcher object.
-    def permit_mass_assignment_of(*attributes)
+    def permit_attributes(*attributes)
       PermitAttributesMatcher.new(*attributes)
     end
 
-    RSpec::Matchers.define_negated_matcher :forbid_mass_assignment_of, :permit_mass_assignment_of, &NEGATED_DESCRIPTION
+    RSpec::Matchers.define_negated_matcher :forbid_attributes, :permit_attributes, &NEGATED_DESCRIPTION
+
+    # @!macro [attach] RSpec::Matchers.alias_matcher
+    #   @!method $1
+    #
+    #   An alias matcher for {$2}.
+    RSpec::Matchers.alias_matcher :permit_mass_assignment_of, :permit_attributes
+    RSpec::Matchers.alias_matcher :forbid_mass_assignment_of, :forbid_attributes
   end
 end
 

--- a/lib/pundit/matchers/attributes_matcher.rb
+++ b/lib/pundit/matchers/attributes_matcher.rb
@@ -8,6 +8,8 @@ module Pundit
     class AttributesMatcher < BaseMatcher
       # Error message to be raised when no attributes are specified.
       ARGUMENTS_REQUIRED_ERROR = 'At least one attribute must be specified'
+      # Error message to be raised when only one attribute may be specified.
+      ONE_ARGUMENT_REQUIRED_ERROR = 'Only one attribute may be specified'
 
       # Initializes a new instance of the AttributesMatcher class.
       #
@@ -26,6 +28,17 @@ module Pundit
       # @return [AttributesMatcher] The current instance of the AttributesMatcher class.
       def for_action(action)
         @options[:action] = action
+        self
+      end
+
+      # Ensures that only one attribute is specified.
+      #
+      # @raise [ArgumentError] If more than one attribute is specified.
+      #
+      # @return [AttributesMatcher] The object itself.
+      def ensure_single_attribute!
+        raise ArgumentError, ONE_ARGUMENT_REQUIRED_ERROR if expected_attributes.size > 1
+
         self
       end
 

--- a/pundit-matchers.gemspec
+++ b/pundit-matchers.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'pundit-matchers'
-  s.version     = '3.0.1'
+  s.version     = '3.1.0'
   s.summary     = 'RSpec matchers for Pundit policies'
   s.description = 'A set of RSpec matchers for testing Pundit authorisation ' \
                   'policies'

--- a/spec/pundit/matchers/permit_attributes_matcher_spec.rb
+++ b/spec/pundit/matchers/permit_attributes_matcher_spec.rb
@@ -21,11 +21,27 @@ RSpec.describe Pundit::Matchers::PermitAttributesMatcher do
     )
   end
 
-  context 'without actions' do
+  context 'without attributes' do
     it 'raises an argument error' do
       expect do
         described_class.new
       end.to raise_error ArgumentError, described_class::ARGUMENTS_REQUIRED_ERROR
+    end
+  end
+
+  describe '#ensure_single_attribute!' do
+    it 'allows a single nested attribute' do
+      expect do
+        described_class.new(test: %i[nested]).ensure_single_attribute!
+      end.not_to raise_error
+    end
+
+    context 'when matcher has been initializated with more than one attribute' do
+      it 'raises an argument error' do
+        expect do
+          described_class.new(test: %i[nest1 nest2]).ensure_single_attribute!
+        end.to raise_error ArgumentError, described_class::ONE_ARGUMENT_REQUIRED_ERROR
+      end
     end
   end
 
@@ -204,45 +220,110 @@ RSpec.describe Pundit::Matchers::PermitAttributesMatcher do
                        permitted_attributes_for_test: %i[test3])
       end
 
-      it { is_expected.to permit_mass_assignment_of(:test3).for_action(:test) }
-      it { is_expected.to forbid_mass_assignment_of(:test1).for_action(:test) }
+      it { is_expected.to permit_attributes(:test3).for_action(:test) }
+      it { is_expected.to forbid_attributes(:test1).for_action(:test) }
     end
 
     context 'when expectation is met' do
       subject(:policy) { policy_factory(permitted_attributes: %i[test]) }
 
-      it { is_expected.to permit_mass_assignment_of(:test) }
-      it { is_expected.not_to forbid_mass_assignment_of(:test) }
+      it { is_expected.to permit_attributes(:test) }
+      it { is_expected.not_to forbid_attributes(:test) }
 
       it 'provides a user friendly failure message' do
         expect do
-          expect(policy).to forbid_mass_assignment_of(:test)
+          expect(policy).to forbid_attributes(:test)
         end.to fail_with(failure_message_when_negated)
       end
 
       it 'provides a user friendly negated failure message' do
         expect do
-          expect(policy).not_to permit_mass_assignment_of(:test)
+          expect(policy).not_to permit_attributes(:test)
         end.to fail_with(failure_message_when_negated)
+      end
+    end
+
+    context 'with a single attribute matcher' do
+      subject(:policy) { policy_factory(permitted_attributes: []) }
+
+      it 'ensures that it has been called with a single attribute' do
+        expect do
+          expect(policy).to permit_attribute(%i[test test2])
+        end.to raise_error ArgumentError, described_class::ONE_ARGUMENT_REQUIRED_ERROR
       end
     end
 
     context 'when expectation is not met' do
       subject(:policy) { policy_factory(permitted_attributes: []) }
 
-      it { is_expected.not_to permit_mass_assignment_of(:test) }
-      it { is_expected.to forbid_mass_assignment_of(:test) }
+      it { is_expected.not_to permit_attributes(:test) }
+      it { is_expected.to forbid_attributes(:test) }
 
       it 'provides a user friendly failure message' do
         expect do
-          expect(policy).to permit_mass_assignment_of(:test)
+          expect(policy).to permit_attributes(:test)
         end.to fail_with(failure_message)
       end
 
       it 'provides a user friendly negated failure message' do
         expect do
-          expect(policy).not_to forbid_mass_assignment_of(:test)
+          expect(policy).not_to forbid_attributes(:test)
         end.to fail_with(failure_message)
+      end
+    end
+
+    describe 'single attribute matcher' do
+      let(:test_matcher) { instance_double(described_class, matches?: true, ensure_single_attribute!: nil) }
+
+      before do
+        allow(described_class).to receive(:new).and_return(test_matcher)
+        allow(test_matcher).to receive(:ensure_single_attribute!).and_return(test_matcher)
+      end
+
+      it 'defines permit_attribute matcher' do
+        expect(policy).to permit_attribute(:test)
+
+        expect(described_class).to have_received(:new).with(:test)
+      end
+
+      it 'ensures that it has been called with a single action' do
+        expect(policy).to permit_attribute(:test)
+
+        expect(test_matcher).to have_received(:ensure_single_attribute!)
+      end
+    end
+
+    describe 'single attribute negated matcher' do
+      let(:test_matcher) { instance_double(described_class, does_not_match?: true, ensure_single_attribute!: nil) }
+
+      before do
+        allow(described_class).to receive(:new).and_return(test_matcher)
+        allow(test_matcher).to receive(:ensure_single_attribute!).and_return(test_matcher)
+      end
+
+      it 'defines forbid_attribute matcher' do
+        expect(policy).to forbid_attribute(:test)
+
+        expect(described_class).to have_received(:new).with(:test)
+      end
+
+      it 'ensures that it has been called with a single action' do
+        expect(policy).to forbid_attribute(:test)
+
+        expect(test_matcher).to have_received(:ensure_single_attribute!)
+      end
+    end
+
+    describe 'helper matchers' do
+      before do
+        test_matcher = instance_double(described_class, matches?: true)
+        allow(described_class).to receive(:new).and_return(test_matcher)
+      end
+
+      it 'aliases permit_mass_assignment_of to permit_attributes' do
+        expect(policy).to permit_mass_assignment_of(:test)
+
+        expect(described_class).to have_received(:new).with(:test)
       end
     end
 
@@ -252,7 +333,7 @@ RSpec.describe Pundit::Matchers::PermitAttributesMatcher do
         allow(described_class).to receive(:new).and_return(test_matcher)
       end
 
-      it 'defines forbid_mass_assignment_of matcher' do
+      it 'aliases forbid_mass_assignment_of to forbid_attributes' do
         expect(policy).to forbid_mass_assignment_of(:test)
 
         expect(described_class).to have_received(:new).with(:test)


### PR DESCRIPTION
Add `permit_attribute` and `permit_attributes` to match actions API

Also bumps version to 3.1.0

Close #94
