### PR TITLE
Allow dynamic actions to be matched with `permit_action`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Pundit Matchers
 
+## 3.0.1 (unreleased)
+
+- Allow `permit_action` to match dynamic actions
+
 ## 3.0.0 (2023-06-14)
 
 - Drop RSpec < 3.12 and Pundit < 2 compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.0.1 (unreleased)
 
-- Allow `permit_action` to match dynamic actions
+- Allow to match dynamically defined actions
 
 ## 3.0.0 (2023-06-14)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pundit-matchers (3.0.0)
+    pundit-matchers (3.0.1)
       rspec-core (~> 3.12)
       rspec-expectations (~> 3.12)
       rspec-mocks (~> 3.12)

--- a/lib/pundit/matchers/actions_matcher.rb
+++ b/lib/pundit/matchers/actions_matcher.rb
@@ -42,7 +42,7 @@ module Pundit
 
       def check_actions!
         non_explicit_actions = (expected_actions - policy_info.actions)
-        missing_actions = non_explicit_actions.reject { |action| policy_info.policy.respond_to?("#{action}?".to_sym) }
+        missing_actions = non_explicit_actions.reject { |action| policy_info.policy.respond_to?(:"#{action}?") }
         return if missing_actions.empty?
 
         raise ArgumentError, format(

--- a/lib/pundit/matchers/actions_matcher.rb
+++ b/lib/pundit/matchers/actions_matcher.rb
@@ -41,7 +41,8 @@ module Pundit
       attr_reader :expected_actions
 
       def check_actions!
-        missing_actions = expected_actions - policy_info.actions
+        non_explicit_actions = (expected_actions - policy_info.actions)
+        missing_actions = non_explicit_actions.reject { |action| policy_info.policy.respond_to?("#{action}?".to_sym) }
         return if missing_actions.empty?
 
         raise ArgumentError, format(

--- a/pundit-matchers.gemspec
+++ b/pundit-matchers.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'pundit-matchers'
-  s.version     = '3.0.0'
+  s.version     = '3.0.1'
   s.summary     = 'RSpec matchers for Pundit policies'
   s.description = 'A set of RSpec matchers for testing Pundit authorisation ' \
                   'policies'

--- a/spec/policy_factory.rb
+++ b/spec/policy_factory.rb
@@ -14,6 +14,19 @@ class TestPolicy
   end
 end
 
+class DynamicTestPolicy < TestPolicy
+  def method_missing(method, *args, &block)
+    method_s = method.to_s
+    return super unless method_s.end_with?('?')
+
+    method_s.match?(/^poke/)
+  end
+
+  def respond_to_missing?(method, include_private = false)
+    method.to_s.end_with?('?') || super
+  end
+end
+
 module PolicyFactory
   def policy_factory(**actions)
     policy_class = Class.new(TestPolicy) do

--- a/spec/pundit/matchers/permit_actions_matcher_spec.rb
+++ b/spec/pundit/matchers/permit_actions_matcher_spec.rb
@@ -98,6 +98,12 @@ RSpec.describe Pundit::Matchers::PermitActionsMatcher do
       "expected 'TestPolicy' to forbid [:test], but permitted [:test] for 'user'"
     end
 
+    context 'when policy has dynamic action' do
+      subject(:policy) { DynamicTestPolicy.new }
+
+      it { is_expected.to permit_actions(:poke) }
+    end
+
     context 'when expectation is met' do
       subject(:policy) { policy_factory(test?: true) }
 


### PR DESCRIPTION
Fixing https://github.com/punditcommunity/pundit-matchers/issues/101

3.0.0 broke the permit_action matcher for policies with dynamic actions. Here's an attempt to bring back the pre-3.0.0 behaviour. 