### PR TITLE
Update Dockerfile to reflect requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ LABEL maintainer="chris@chrisalley.info"
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends
 
-COPY Gemfile* /lib/
+COPY Gemfile* pundit-matchers.gemspec /lib/
 WORKDIR /lib
-RUN gem install bundler:2.4.12
+RUN gem install bundler:2.4.13
 RUN bundle install
 
 COPY . /lib


### PR DESCRIPTION
In order to make the out-of-the-box developer experience flawless, the installed bundle version needs to match the version in `Gemfile.lock` and for bundle install to succeed the `pundit-matchers.gemspec` needs to be in `/lib`.

(As requested per https://github.com/punditcommunity/pundit-matchers/pull/102#discussion_r1230479817)