### PR TITLE
Add back composability support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Pundit Matchers
 
+## 3.1.1 (unreleased)
+
+- Fix composability support
+
 ## 3.1.0 (2023-06-19)
 
 - Add `*_attribute(s)` matchers for uniformity with `*_action(s)`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pundit-matchers (3.1.0)
+    pundit-matchers (3.1.1)
       rspec-core (~> 3.12)
       rspec-expectations (~> 3.12)
       rspec-mocks (~> 3.12)

--- a/lib/pundit/matchers/base_matcher.rb
+++ b/lib/pundit/matchers/base_matcher.rb
@@ -6,6 +6,8 @@ module Pundit
   module Matchers
     # This is the base class for all matchers in the Pundit Matchers library.
     class BaseMatcher
+      include RSpec::Matchers::Composable
+
       # Error message when an ambiguous negated matcher is used.
       AMBIGUOUS_NEGATED_MATCHER_ERROR = <<~MSG
         `expect().not_to %<name>s` is not supported since it creates ambiguity.

--- a/pundit-matchers.gemspec
+++ b/pundit-matchers.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'pundit-matchers'
-  s.version     = '3.1.0'
+  s.version     = '3.1.1'
   s.summary     = 'RSpec matchers for Pundit policies'
   s.description = 'A set of RSpec matchers for testing Pundit authorisation ' \
                   'policies'

--- a/spec/pundit/matchers/permit_actions_matcher_spec.rb
+++ b/spec/pundit/matchers/permit_actions_matcher_spec.rb
@@ -104,6 +104,14 @@ RSpec.describe Pundit::Matchers::PermitActionsMatcher do
       it { is_expected.to permit_actions(:poke) }
     end
 
+    it 'supports composability' do
+      policy = policy_factory(test1?: true, test2?: false)
+
+      expect(policy)
+        .to permit_actions(:test1)
+        .and forbid_actions(:test2)
+    end
+
     context 'when expectation is met' do
       subject(:policy) { policy_factory(test?: true) }
 

--- a/spec/pundit/matchers/permit_attributes_matcher_spec.rb
+++ b/spec/pundit/matchers/permit_attributes_matcher_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Pundit::Matchers::PermitAttributesMatcher do
+  it_behaves_like 'a composable matcher'
+
   it 'initializes expected attributes with a single attribute' do
     expect(described_class.new(:test).send(:expected_attributes)).to eq %i[test]
   end
@@ -212,6 +214,14 @@ RSpec.describe Pundit::Matchers::PermitAttributesMatcher do
     let(:failure_message_when_negated) do
       "expected 'TestPolicy' to forbid the mass assignment of [:test], " \
         "but permitted the mass assignment of [:test] for 'user'"
+    end
+
+    it 'supports composability' do
+      policy = policy_factory(permitted_attributes: %i[test1])
+
+      expect(policy)
+        .to permit_attribute(:test1)
+        .and forbid_attribute(:test2)
     end
 
     context 'with for_action chain' do

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
+RSpec.shared_examples_for 'a composable matcher' do
+  it 'is composable' do
+    expect(described_class).to include(RSpec::Matchers::Composable)
+  end
+end
+
 RSpec.shared_examples_for 'an actions matcher' do
+  it_behaves_like 'a composable matcher'
+
   it 'initializes expected actions with a single action' do
     expect(described_class.new(:test).send(:expected_actions)).to eq %i[test]
   end


### PR DESCRIPTION
Prior to v3, the attributes matcher was defined using the RSpec DSL which meant that the resulting matcher(s) was a subclass of RSpec's built-in matcher hierarchy.

This meant that the matchers were chainable, composable, diffable, and recursive.

The v3 base matcher does not inherit from the core RSpec matchers, and thus breaks the interfaces that RSpec matchers support.

This changes adds `RSpec::Matchers::Composable` to the base matcher to add back composability support

Fix #107